### PR TITLE
feat: add Windows portable zip to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,41 @@ jobs:
           updaterJsonKeepUniversal: true
           args: ${{ matrix.tauri-args }}
 
+      # ── Windows portable zip (no installer needed) ──────────────
+      - name: Create Windows portable zip
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          $exePath = "src-tauri\target\release\rxterm.exe"
+          if (-not (Test-Path $exePath)) {
+            Write-Host "ERROR: $exePath not found" -ForegroundColor Red
+            exit 1
+          }
+          $zipDir = New-Item -ItemType Directory -Path "$env:RUNNER_TEMP\portable" -Force
+          Copy-Item $exePath $zipDir
+          # Include a readme for the portable package
+          @"
+          RxTerm ${{ env.APP_VERSION }} — Portable Edition
+
+          Just run rxterm.exe — no installation required.
+          Settings are stored in %APPDATA%\RxTerm\.
+          "@ | Set-Content (Join-Path $zipDir "README.txt")
+          $zipName = "RxTerm_${{ env.APP_VERSION }}_windows_portable.zip"
+          Compress-Archive -Path "$zipDir\*" -DestinationPath $zipName -Force
+          Write-Host "Created portable zip: $zipName"
+
+      - name: Upload Windows portable zip to release
+        if: matrix.platform == 'windows-latest'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="${{ github.ref_name }}"
+          ZIP_NAME="RxTerm_${APP_VERSION}_windows_portable.zip"
+          gh release upload "$TAG" "$ZIP_NAME" \
+            --repo "${{ github.repository }}" \
+            --clobber
+
   # ── Checksums ───────────────────────────────────────────────────────
   checksums:
     needs: build
@@ -204,6 +239,7 @@ jobs:
             --pattern "*.app.tar.gz" \
             --pattern "*.deb.tar.gz" \
             --pattern "*.AppImage.tar.gz" \
+            --pattern "*_portable.zip" \
             --clobber || true
 
       - name: Generate SHA-256 checksums

--- a/build-release.ps1
+++ b/build-release.ps1
@@ -1,4 +1,4 @@
-# build-release.ps1 — Build RxTerm release artifacts (MSI + EXE installer)
+# build-release.ps1 — Build RxTerm release artifacts (MSI + EXE + portable zip)
 # Usage: .\build-release.ps1 -Version 0.2.0
 
 param(
@@ -72,6 +72,29 @@ if ($nsis) {
     Copy-Item -Path $nsis.FullName -Destination (Join-Path $releaseDir $destName) -Force
     $copied++
     Write-Host "  EXE:  $(Join-Path $releaseDir $destName)" -ForegroundColor Cyan
+}
+
+# Create portable zip (no installation required — just unzip and run)
+$portableExe = Join-Path $PSScriptRoot "src-tauri\target\release\rxterm.exe"
+if (Test-Path $portableExe) {
+    $portableDir = Join-Path $releaseDir "portable"
+    if (-not (Test-Path $portableDir)) {
+        New-Item -ItemType Directory -Path $portableDir | Out-Null
+    }
+    Copy-Item -Path $portableExe -Destination $portableDir -Force
+    @"
+RxTerm $Version — Portable Edition
+
+Just run rxterm.exe — no installation required.
+Settings are stored in %APPDATA%\RxTerm\.
+"@ | Set-Content (Join-Path $portableDir "README.txt") -Encoding UTF8
+
+    $zipName = "RxTerm_${Version}_windows_portable.zip"
+    $zipPath = Join-Path $releaseDir $zipName
+    Compress-Archive -Path "$portableDir\*" -DestinationPath $zipPath -Force
+    Remove-Item -Recurse -Force $portableDir
+    $copied++
+    Write-Host "  ZIP:  $zipPath" -ForegroundColor Cyan
 }
 
 Write-Host "`n=== Build Complete ===" -ForegroundColor Green


### PR DESCRIPTION
## Summary

- Add a no-install-needed Windows portable zip (`RxTerm_{version}_windows_portable.zip`) to the release pipeline
- CI creates the zip after the Tauri build, containing `rxterm.exe` + `README.txt`, and uploads it to the GitHub release
- Checksums job updated to include the portable zip in SHA-256 hashing
- `build-release.ps1` also produces the portable zip for local builds

Users can download the zip, extract anywhere, and run `rxterm.exe` directly — no installation, no admin rights, no registry entries. Settings are stored in `%APPDATA%\RxTerm\`.

## Test plan
- [ ] Trigger a release build and verify `RxTerm_{version}_windows_portable.zip` appears in GitHub release assets
- [ ] Download the portable zip, extract, and confirm `rxterm.exe` launches without installation
- [ ] Verify `checksums-sha256.txt` includes the portable zip hash

https://claude.ai/code/session_014RKCoqaMaJRSLyzMgoowjQ