### PR TITLE
fix: constrain VNC pane to its tab instead of taking full screen

### DIFF
--- a/src/components/VncPane.tsx
+++ b/src/components/VncPane.tsx
@@ -42,8 +42,12 @@ export default function VncPane({
     const rfb = new RFB(containerRef.current, url, {
       credentials: passwordRef.current ? { password: passwordRef.current } : undefined,
     });
+    // Scale the remote desktop to fit the container — keeps VNC inside its
+    // tab pane instead of overflowing to full screen.
     rfb.scaleViewport = true;
-    rfb.resizeSession = true;
+    // Do NOT resize the remote session to match the container — that causes
+    // the server to resize and the canvas to grow unbounded.
+    rfb.resizeSession = false;
     rfbRef.current = rfb;
 
     rfb.addEventListener("disconnect", (e: CustomEvent) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -851,6 +851,17 @@ button:disabled {
   width: 100%;
   height: 100%;
   background-color: var(--bg-pane);
+  overflow: hidden;
+  position: relative;
+}
+
+/* Constrain noVNC's internal elements to the container */
+.vnc-container > div {
+  width: 100% !important;
+  height: 100% !important;
+  position: absolute !important;
+  inset: 0 !important;
+  overflow: hidden !important;
 }
 
 .rdp-container {


### PR DESCRIPTION
## Summary

Fix VNC sessions taking over the full screen instead of staying within their tab pane.

**Root cause:** noVNC's `resizeSession = true` tells the remote VNC server to resize to match the container, which combined with `scaleViewport = true` creates a feedback loop where the canvas grows unbounded. Additionally, noVNC's internal `<div>` wrapper was not constrained by CSS overflow rules.

**Fix:**
1. **CSS**: `.vnc-container` gets `overflow: hidden` + `position: relative`, and noVNC's inner div is force-constrained with `position: absolute; inset: 0`
2. **VncPane.tsx**: Disable `resizeSession` — keep only `scaleViewport = true` so the remote desktop scales to fit inside the tab pane

## Test plan
- [ ] Connect to a VNC host — session renders inside tab pane, not fullscreen
- [ ] SSH and RDP tabs still render correctly alongside VNC tabs
- [ ] VNC session scales proportionally when resizing the window

https://claude.ai/code/session_014RKCoqaMaJRSLyzMgoowjQ