### PR TITLE
feat: show error overlay with Reconnect button on VNC/RDP failure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -469,11 +469,21 @@ export default function App() {
                       wsPort={conn.wsPort}
                       password={conn.vncPassword}
                       onDisconnected={() => handleRemoteDisconnect(conn.id)}
+                      onReconnect={() => {
+                        const session = sessions.find((s) => s.id === conn.sessionId);
+                        removeConnection(conn.id);
+                        if (session) handleConnect(session);
+                      }}
                     />
                   ) : conn.protocol === "rdp" ? (
                     <RdpPane
                       connectionId={conn.id}
                       onDisconnected={() => handleRemoteDisconnect(conn.id)}
+                      onReconnect={() => {
+                        const session = sessions.find((s) => s.id === conn.sessionId);
+                        removeConnection(conn.id);
+                        if (session) handleConnect(session);
+                      }}
                     />
                   ) : (
                     <TerminalPane

--- a/src/components/RdpPane.tsx
+++ b/src/components/RdpPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import type { MouseEvent, WheelEvent, KeyboardEvent } from "react";
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
 import type { RdpFramePayload, RdpDisconnectedPayload } from "../types";
@@ -7,8 +7,10 @@ import { rdpMouseEvent, rdpKeyEvent } from "../api";
 interface RdpPaneProps {
   /** Unique connection identifier from the backend. */
   connectionId: string;
-  /** Called when the RDP session is closed (by server or error). */
+  /** Called when the user explicitly closes the tab. */
   onDisconnected: () => void;
+  /** Called to re-establish the connection (reconnect). */
+  onReconnect: () => void;
 }
 
 /** PERF-4 fix: scancode map as a module-level constant. */
@@ -71,13 +73,15 @@ const SCANCODE_MAP: Record<string, number> = {
  * - This component paints each dirty rect onto the canvas using `putImageData`
  * - Keyboard / mouse events are forwarded to the backend via Tauri commands
  */
-export default function RdpPane({ connectionId, onDisconnected }: RdpPaneProps) {
+export default function RdpPane({ connectionId, onDisconnected, onReconnect }: RdpPaneProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const connectionIdRef = useRef(connectionId);
   const onDisconnectedRef = useRef(onDisconnected);
   // PERF-5 fix: cache the 2D context in a ref
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const hasReceivedFrame = useRef(false);
 
   // Keep refs in sync with latest props so closures never stale-capture them
   connectionIdRef.current = connectionId;
@@ -123,6 +127,7 @@ export default function RdpPane({ connectionId, onDisconnected }: RdpPaneProps) 
 
     listen<RdpFramePayload>("rdp-frame", (event) => {
       if (event.payload.connection_id === connectionIdRef.current) {
+        hasReceivedFrame.current = true;
         blitFrame(event.payload);
       }
     }).then((fn) => {
@@ -131,7 +136,9 @@ export default function RdpPane({ connectionId, onDisconnected }: RdpPaneProps) 
 
     listen<RdpDisconnectedPayload>("rdp-disconnected", (event) => {
       if (event.payload.connection_id === connectionIdRef.current) {
-        onDisconnectedRef.current();
+        const reason = event.payload.reason || "Connection closed";
+        // Show error in the pane instead of closing the tab
+        setError(`RDP session ended: ${reason}`);
       }
     }).then((fn) => {
       if (cancelled) { fn(); } else { unlisteners.push(fn); }
@@ -212,6 +219,24 @@ export default function RdpPane({ connectionId, onDisconnected }: RdpPaneProps) 
       rdpKeyEvent(connectionIdRef.current, scancode, false).catch(() => {});
     }
   }, []);
+
+  if (error) {
+    return (
+      <div className="pane-error">
+        <div className="pane-error-icon">&#x26A0;</div>
+        <div className="pane-error-title">Connection Failed</div>
+        <div className="pane-error-message">{error}</div>
+        <div className="pane-error-actions">
+          <button className="btn-primary" onClick={onReconnect}>
+            Reconnect
+          </button>
+          <button className="btn-secondary" onClick={onDisconnected}>
+            Close Tab
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/VncPane.tsx
+++ b/src/components/VncPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import RFB from "@novnc/novnc/lib/rfb";
 
 interface VncPaneProps {
@@ -8,27 +8,30 @@ interface VncPaneProps {
   wsPort: number;
   /** VNC password for the RFB handshake (optional). */
   password?: string;
-  /** Called when the VNC connection is closed. */
+  /** Called when the user explicitly closes the tab. */
   onDisconnected: () => void;
+  /** Called to re-establish the connection (reconnect). */
+  onReconnect: () => void;
 }
 
 /**
  * Renders a VNC remote desktop session using noVNC.
  *
- * Data flow:
- * - noVNC connects via WebSocket to a local proxy (127.0.0.1:wsPort)
- * - The Rust backend proxies the WebSocket to the real VNC server
+ * On connection failure or unclean disconnect, shows an error overlay
+ * with a Reconnect button instead of closing the tab.
  */
 export default function VncPane({
   connectionId,
   wsPort,
   password,
   onDisconnected,
+  onReconnect,
 }: VncPaneProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rfbRef = useRef<RFB | null>(null);
   const passwordRef = useRef(password);
   const onDisconnectedRef = useRef(onDisconnected);
+  const [error, setError] = useState<string | null>(null);
 
   // Keep refs in sync with latest props
   passwordRef.current = password;
@@ -36,6 +39,7 @@ export default function VncPane({
 
   useEffect(() => {
     if (!containerRef.current) return;
+    setError(null);
 
     const url = `ws://127.0.0.1:${wsPort}`;
 
@@ -53,16 +57,19 @@ export default function VncPane({
     rfb.addEventListener("disconnect", (e: CustomEvent) => {
       const clean = e.detail?.clean ?? false;
       if (!clean) {
-        console.warn(`[VNC ${connectionId}] unclean disconnect`);
+        // Show error in the pane instead of closing the tab
+        setError("VNC connection lost unexpectedly.");
+      } else {
+        // Clean disconnect (user-initiated) — close the tab
+        onDisconnectedRef.current();
       }
-      onDisconnectedRef.current();
     });
 
     rfb.addEventListener("credentialsrequired", () => {
       if (passwordRef.current) {
         rfb.sendCredentials({ password: passwordRef.current });
       } else {
-        rfb.disconnect();
+        setError("VNC server requires a password but none was provided.");
       }
     });
 
@@ -73,6 +80,24 @@ export default function VncPane({
       }
     };
   }, [connectionId, wsPort]);
+
+  if (error) {
+    return (
+      <div className="pane-error">
+        <div className="pane-error-icon">&#x26A0;</div>
+        <div className="pane-error-title">Connection Failed</div>
+        <div className="pane-error-message">{error}</div>
+        <div className="pane-error-actions">
+          <button className="btn-primary" onClick={onReconnect}>
+            Reconnect
+          </button>
+          <button className="btn-secondary" onClick={onDisconnected}>
+            Close Tab
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/styles.css
+++ b/src/styles.css
@@ -875,6 +875,50 @@ button:disabled {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
+   Pane error overlay (VNC / RDP connection failure)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+.pane-error {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--bg-pane);
+  color: var(--text-primary);
+  gap: 8px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.pane-error-icon {
+  font-size: 2.5rem;
+  color: var(--warning);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.pane-error-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.pane-error-message {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  max-width: 400px;
+  line-height: 1.5;
+}
+
+.pane-error-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
    Dialog overlay — Fluent Design modal
    ═══════════════════════════════════════════════════════════════════════ */
 


### PR DESCRIPTION
## Summary

When a VNC or RDP connection fails or disconnects unexpectedly, the tab now stays open with an error overlay instead of silently closing.

The error overlay shows:
- Warning icon and "Connection Failed" title
- The specific error/disconnect reason
- **Reconnect** button — removes the dead connection and re-initiates the connect flow
- **Close Tab** button — removes the tab (previous behavior)

### Behavior by protocol

| Protocol | Failure behavior |
|----------|-----------------|
| **VNC** | Unclean disconnect → error overlay; clean disconnect (user-initiated) → closes tab |
| **RDP** | Backend disconnect event → error overlay with server reason |
| **SSH** | Unchanged — already shows `[Disconnected: reason]` inline via xterm |

## Test plan
- [ ] Connect to a VNC host, kill the VNC server → tab stays open with error + Reconnect button
- [ ] Click Reconnect → old tab removed, new connection initiated
- [ ] Click Close Tab → tab removed normally
- [ ] Connect to an RDP host with wrong credentials → error overlay shown
- [ ] SSH disconnect still shows inline message as before

https://claude.ai/code/session_014RKCoqaMaJRSLyzMgoowjQ