### PR TITLE
fix: distinct warning when an SSH host key has changed (potential MITM)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -175,7 +175,9 @@ pub async fn import_sessions(json: String) -> Result<Vec<SshSession>, AppError> 
 ///
 /// The frontend checks `result.status`:
 /// - `"connected"` → connection established, `connection_id` is set
-/// - `"host_key_unknown"` → key needs approval, `host_key` is set
+/// - `"host_key_unknown"` → first-time key needs approval, `host_key` is set
+/// - `"host_key_changed"` → key DIFFERS from the stored entry (potential
+///   MITM), `host_key` is set and the UI must warn prominently
 #[derive(serde::Serialize)]
 pub struct SshConnectResult {
     pub status: String,
@@ -191,6 +193,9 @@ pub struct HostKeyInfo {
     pub fingerprint: String,
     pub key_data: String,
     pub algorithm: String,
+    /// True when a different key was previously accepted for this host
+    /// (potential MITM) — distinct from a first-time unknown key.
+    pub changed: bool,
 }
 
 /// Initiate an SSH connection to the server specified by `session_id`.
@@ -250,13 +255,19 @@ pub async fn ssh_connect(
         }),
         Err(crate::ssh::ConnectError::HostKeyUnknown(info)) => {
             // ROB-6: return structured data instead of embedding JSON in error string
+            let status = if info.changed {
+                "host_key_changed"
+            } else {
+                "host_key_unknown"
+            };
             Ok(SshConnectResult {
-                status: "host_key_unknown".to_string(),
+                status: status.to_string(),
                 connection_id: None,
                 host_key: Some(HostKeyInfo {
                     fingerprint: info.fingerprint,
                     key_data: info.key_data,
                     algorithm: info.algorithm,
+                    changed: info.changed,
                 }),
             })
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -200,10 +200,11 @@ pub struct HostKeyInfo {
 
 /// Initiate an SSH connection to the server specified by `session_id`.
 ///
-/// If the host key is unknown, returns an error whose message starts with
-/// `HOST_KEY_UNKNOWN:` followed by a JSON-encoded `HostKeyInfo`. The
-/// frontend should prompt the user and call `ssh_accept_host_key` before
-/// retrying.
+/// If the host key is not yet trusted, returns `Ok` with `status`
+/// `"host_key_unknown"` (first contact) or `"host_key_changed"` (a
+/// different key than previously accepted — potential MITM) and the
+/// `host_key` field populated. The frontend prompts the user and calls
+/// `ssh_accept_host_key` before retrying.
 #[tauri::command]
 pub async fn ssh_connect(
     app: AppHandle,

--- a/src-tauri/src/known_hosts.rs
+++ b/src-tauri/src/known_hosts.rs
@@ -70,8 +70,14 @@ impl KnownHostsStore {
 
         let _guard = self.file_lock.lock().unwrap_or_else(|e| e.into_inner());
         let entries = self.load_entries();
+
+        let mut host_seen = false;
         for entry in &entries {
-            if entry.host == entry_host && entry.algorithm == algo {
+            if entry.host != entry_host {
+                continue;
+            }
+            host_seen = true;
+            if entry.algorithm == algo {
                 if entry.key_data == encoded {
                     return HostKeyStatus::Known;
                 }
@@ -80,6 +86,19 @@ impl KnownHostsStore {
                     key_data: encoded,
                 };
             }
+        }
+
+        // The host is already trusted under a different key algorithm but is
+        // now presenting a key type we have never accepted. A legitimate
+        // server keeps offering a key we know, so treat this as the
+        // potential-MITM case — otherwise an attacker could downgrade to an
+        // absent algorithm to dodge the changed-key warning — rather than a
+        // benign first contact.
+        if host_seen {
+            return HostKeyStatus::Changed {
+                fingerprint,
+                key_data: encoded,
+            };
         }
 
         HostKeyStatus::Unknown {
@@ -276,6 +295,23 @@ mod tests {
         assert!(matches!(
             store.check("example.com", 2222, &impostor),
             HostKeyStatus::Unknown { .. }
+        ));
+    }
+
+    #[test]
+    fn check_returns_changed_when_known_host_presents_a_new_key_algorithm() {
+        let (store, _dir) = temp_store();
+        // Trust the host under a non-ed25519 algorithm.
+        store
+            .accept("example.com", 22, "AAAAB3NzaC1yc2EAAAA", "ssh-rsa")
+            .expect("accept");
+
+        // The host now presents an ed25519 key we have never accepted.
+        // A downgrade to an absent algorithm must NOT dodge the warning.
+        let ed25519 = generate_key();
+        assert!(matches!(
+            store.check("example.com", 22, &ed25519),
+            HostKeyStatus::Changed { .. }
         ));
     }
 

--- a/src-tauri/src/known_hosts.rs
+++ b/src-tauri/src/known_hosts.rs
@@ -217,6 +217,68 @@ mod tests {
         (store, dir)
     }
 
+    /// Helper: generate a fresh ed25519 public key for check() tests.
+    fn generate_key() -> PublicKey {
+        russh_keys::key::KeyPair::generate_ed25519()
+            .clone_public_key()
+            .expect("clone public key")
+    }
+
+    // ── check(): Known / Unknown / Changed status ─────────────────
+
+    #[test]
+    fn check_returns_unknown_for_new_host() {
+        let (store, _dir) = temp_store();
+        let key = generate_key();
+        assert!(matches!(
+            store.check("example.com", 22, &key),
+            HostKeyStatus::Unknown { .. }
+        ));
+    }
+
+    #[test]
+    fn check_returns_known_for_accepted_key() {
+        let (store, _dir) = temp_store();
+        let key = generate_key();
+        store
+            .accept(
+                "example.com",
+                22,
+                &key.public_key_base64(),
+                &key_algorithm_name(&key),
+            )
+            .expect("accept");
+        assert!(matches!(
+            store.check("example.com", 22, &key),
+            HostKeyStatus::Known
+        ));
+    }
+
+    #[test]
+    fn check_returns_changed_for_different_key_same_host() {
+        let (store, _dir) = temp_store();
+        let original = generate_key();
+        store
+            .accept(
+                "example.com",
+                22,
+                &original.public_key_base64(),
+                &key_algorithm_name(&original),
+            )
+            .expect("accept");
+
+        let impostor = generate_key();
+        assert!(matches!(
+            store.check("example.com", 22, &impostor),
+            HostKeyStatus::Changed { .. }
+        ));
+        // A different port is a separate identity — first contact, not MITM.
+        assert!(matches!(
+            store.check("example.com", 2222, &impostor),
+            HostKeyStatus::Unknown { .. }
+        ));
+    }
+
     // ── SEC-2: Known-hosts injection ─────────────────────────────
 
     #[test]

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -35,6 +35,10 @@ pub struct CapturedHostKeyInfo {
     pub fingerprint: String,
     pub key_data: String,
     pub algorithm: String,
+    /// True when a different key was previously accepted for this host —
+    /// the potential-MITM case, which the UI must present distinctly from
+    /// a first-time unknown key.
+    pub changed: bool,
 }
 
 /// A live SSH connection with its IO handles.
@@ -355,13 +359,29 @@ impl client::Handler for ClientHandler {
             .check(&self.host, self.port, server_public_key)
         {
             HostKeyStatus::Known => Ok(true),
-            HostKeyStatus::Unknown { .. } | HostKeyStatus::Changed { .. } => {
+            HostKeyStatus::Unknown { .. } => {
                 // SEC-3: store key info for the caller before rejecting
                 let mut captured = self.captured_key.lock().await;
                 *captured = Some(CapturedHostKeyInfo {
                     fingerprint,
                     key_data,
                     algorithm,
+                    changed: false,
+                });
+                Ok(false)
+            }
+            HostKeyStatus::Changed { .. } => {
+                log::warn!(
+                    "[SSH] host key for {}:{} CHANGED from the stored entry (potential MITM)",
+                    self.host,
+                    self.port
+                );
+                let mut captured = self.captured_key.lock().await;
+                *captured = Some(CapturedHostKeyInfo {
+                    fingerprint,
+                    key_data,
+                    algorithm,
+                    changed: true,
                 });
                 Ok(false)
             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -301,7 +301,11 @@ export default function App() {
         const result = await sshConnect(session.id, pw);
 
         // ROB-6: typed response — check status instead of parsing error strings
-        if (result.status === "host_key_unknown" && result.host_key) {
+        if (
+          (result.status === "host_key_unknown" ||
+            result.status === "host_key_changed") &&
+          result.host_key
+        ) {
           setHostKeyPrompt({
             host: session.host,
             port: session.port,
@@ -544,6 +548,7 @@ export default function App() {
           host={hostKeyPrompt.host}
           port={hostKeyPrompt.port}
           fingerprint={hostKeyPrompt.info.fingerprint}
+          changed={hostKeyPrompt.info.changed}
           onAccept={handleAcceptHostKey}
           onReject={() => setHostKeyPrompt(null)}
         />

--- a/src/api.ts
+++ b/src/api.ts
@@ -35,12 +35,14 @@ export async function importSessions(json: string): Promise<SshSession[]> {
 
 /** ROB-6: typed result from ssh_connect — no more parsing error strings. */
 export interface SshConnectResponse {
-  status: "connected" | "host_key_unknown";
+  /** "host_key_changed" means the key DIFFERS from the stored entry (potential MITM). */
+  status: "connected" | "host_key_unknown" | "host_key_changed";
   connection_id?: string;
   host_key?: {
     fingerprint: string;
     key_data: string;
     algorithm: string;
+    changed: boolean;
   };
 }
 

--- a/src/components/HostKeyDialog.tsx
+++ b/src/components/HostKeyDialog.tsx
@@ -30,11 +30,19 @@ export default function HostKeyDialog({
   onReject,
 }: HostKeyDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const rejectRef = useRef<HTMLButtonElement>(null);
 
-  // Focus the dialog when it mounts
+  // On mount, focus Reject for the changed-key (danger) variant so the
+  // safe action is the keyboard default; otherwise focus the dialog
+  // container. This effect runs after React's commit-phase autoFocus, so
+  // it — not a button autoFocus attribute — decides the initial focus.
   useEffect(() => {
-    dialogRef.current?.focus();
-  }, []);
+    if (changed && rejectRef.current) {
+      rejectRef.current.focus();
+    } else {
+      dialogRef.current?.focus();
+    }
+  }, [changed]);
 
   // Trap focus within the dialog and handle Escape key
   const handleKeyDown = useCallback(
@@ -121,7 +129,11 @@ export default function HostKeyDialog({
         <div className="dialog-actions">
           {changed ? (
             <>
-              <button className="btn-secondary" autoFocus onClick={onReject}>
+              <button
+                ref={rejectRef}
+                className="btn-secondary"
+                onClick={onReject}
+              >
                 Reject (recommended)
               </button>
               <button className="btn-danger" onClick={onAccept}>

--- a/src/components/HostKeyDialog.tsx
+++ b/src/components/HostKeyDialog.tsx
@@ -7,6 +7,8 @@ interface HostKeyDialogProps {
   port: number;
   /** Key fingerprint to display to the user. */
   fingerprint: string;
+  /** True when a DIFFERENT key was previously accepted (potential MITM). */
+  changed: boolean;
   /** Called when the user accepts the key. */
   onAccept: () => void;
   /** Called when the user rejects the key. */
@@ -23,6 +25,7 @@ export default function HostKeyDialog({
   host,
   port,
   fingerprint,
+  changed,
   onAccept,
   onReject,
 }: HostKeyDialogProps) {
@@ -69,7 +72,7 @@ export default function HostKeyDialog({
     <div className="dialog-overlay" onClick={onReject}>
       <div
         ref={dialogRef}
-        className="dialog-box"
+        className={changed ? "dialog-box dialog-box-danger" : "dialog-box"}
         role="dialog"
         aria-modal="true"
         aria-labelledby="hk-dialog-title"
@@ -77,23 +80,64 @@ export default function HostKeyDialog({
         onClick={(e) => e.stopPropagation()}
         onKeyDown={handleKeyDown}
       >
-        <h3 id="hk-dialog-title">Unknown Host Key</h3>
-        <p>
-          The server at <strong>{host}:{port}</strong> presented an unrecognized
-          host key. This is normal for first-time connections, but could indicate
-          a man-in-the-middle attack if you&apos;ve connected before.
-        </p>
-        <div className="dialog-fingerprint">
-          <code>{fingerprint}</code>
-        </div>
-        <p>Do you want to trust this key and continue connecting?</p>
+        {changed ? (
+          <>
+            <h3 id="hk-dialog-title" className="dialog-title-danger">
+              ⚠ Host Key Changed
+            </h3>
+            <p>
+              <strong>
+                The host key for {host}:{port} is DIFFERENT from the key you
+                previously accepted.
+              </strong>{" "}
+              This can mean the server was reinstalled or its keys were
+              rotated — but it can also mean someone is intercepting your
+              connection (a man-in-the-middle attack).
+            </p>
+            <div className="dialog-fingerprint">
+              <code>{fingerprint}</code>
+            </div>
+            <p>
+              Do not continue unless you can verify the new key with the
+              server administrator. Accepting will permanently replace the
+              stored key.
+            </p>
+          </>
+        ) : (
+          <>
+            <h3 id="hk-dialog-title">Unknown Host Key</h3>
+            <p>
+              The server at <strong>{host}:{port}</strong> presented an
+              unrecognized host key. This is normal for first-time
+              connections, but could indicate a man-in-the-middle attack if
+              you&apos;ve connected before.
+            </p>
+            <div className="dialog-fingerprint">
+              <code>{fingerprint}</code>
+            </div>
+            <p>Do you want to trust this key and continue connecting?</p>
+          </>
+        )}
         <div className="dialog-actions">
-          <button className="btn-primary" onClick={onAccept}>
-            Accept &amp; Connect
-          </button>
-          <button className="btn-secondary" onClick={onReject}>
-            Reject
-          </button>
+          {changed ? (
+            <>
+              <button className="btn-secondary" autoFocus onClick={onReject}>
+                Reject (recommended)
+              </button>
+              <button className="btn-danger" onClick={onAccept}>
+                Replace Key &amp; Connect
+              </button>
+            </>
+          ) : (
+            <>
+              <button className="btn-primary" onClick={onAccept}>
+                Accept &amp; Connect
+              </button>
+              <button className="btn-secondary" onClick={onReject}>
+                Reject
+              </button>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -932,6 +932,15 @@ button:disabled {
   font-weight: 600;
 }
 
+/* Changed-host-key (potential MITM) variant */
+.dialog-box-danger {
+  border-color: var(--error);
+}
+
+.dialog-box .dialog-title-danger {
+  color: var(--error);
+}
+
 .dialog-box p {
   color: var(--text-secondary);
   font-size: 0.85rem;

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,8 @@ export interface HostKeyInfo {
   fingerprint: string;
   key_data: string;
   algorithm: string;
+  /** True when a different key was previously accepted for this host (potential MITM). */
+  changed: boolean;
 }
 
 /** Prompt state tracked while awaiting user host-key decision. */


### PR DESCRIPTION
## Summary

From the status-review backlog: `known_hosts.rs` distinguishes a **changed** host key (potential MITM) from a first-time unknown key, but `ssh.rs` collapsed both into one arm and the frontend showed the same benign prompt for both — losing the security signal entirely.

- `CapturedHostKeyInfo`/`HostKeyInfo` carry a `changed` flag; `ssh_connect` returns `"host_key_changed"` vs `"host_key_unknown"`
- `HostKeyDialog` gains a danger variant: explicit MITM warning copy, **Reject (recommended)** focused by default, danger-styled "Replace Key & Connect"
- A changed key is also logged at warn level on the backend
- New `known_hosts::check()` tests: Known / Unknown / Changed, plus different-port-is-separate-identity

## Test plan
- 30/30 `cargo test` locally; clippy `-D warnings` clean; `tsc` strict clean
- CI validates on ubuntu / windows / macos

🤖 Generated with [Claude Code](https://claude.com/claude-code)