### PR TITLE
chore: harden release pipeline and app config for v0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,16 @@
 name: Release
 
+# Tag-triggered only: a manual workflow_dispatch run would evaluate
+# github.ref_name to a branch name and publish a real release tagged
+# "main" with 0.0.0-dev artifacts.
 on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
 
 env:
   # Extract semver from tag (e.g. "v0.2.0" → "0.2.0").
-  # Falls back to "0.0.0-dev" for manual workflow_dispatch runs without a tag.
+  # The 0.0.0-dev fallback is defense-in-depth for non-tag refs.
   APP_VERSION: ""
 
 jobs:
@@ -233,6 +235,7 @@ jobs:
             --pattern "*.exe" \
             --pattern "*.dmg" \
             --pattern "*.deb" \
+            --pattern "*.rpm" \
             --pattern "*.AppImage" \
             --pattern "*.msi.zip" \
             --pattern "*.nsis.zip" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "rxterm",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rxterm",
-      "version": "0.1.0",
+      "version": "0.6.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@novnc/novnc": "^1.6.0",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-updater": "^2",
         "@xterm/addon-fit": "^0.10.0",
@@ -76,12 +75,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
-    },
-    "node_modules/@novnc/novnc": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.6.0.tgz",
-      "integrity": "sha512-CJrmdSe9Yt2ZbLsJpVFoVkEu0KICEvnr3njW25Nz0jodaiFJtg8AYLGZogRYy0/N5HUWkGUsCmegKXYBSqwygw==",
-      "license": "MPL-2.0"
     },
     "node_modules/@oxc-project/runtime": {
       "version": "0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxterm",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A lightweight, modern terminal and remote session management program built for daily use on Windows. RxTerm aims to provide a streamlined, minimal-setup experience for managing SSH, VNC, and RDP connections — with first-class support for split-screen layouts, tunneling, file transfers, and offline operation.",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5027,7 +5027,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rxterm"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rxterm"
-version = "0.5.1"
+version = "0.6.0"
 description = "A lightweight terminal and remote session management application"
 authors = ["RxTerm Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RxTerm",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "identifier": "com.rxterm.app",
   "build": {
     "beforeDevCommand": "npm run dev",
-    "devUrl": "http://localhost:25326",
+    "devUrl": "http://127.0.0.1:25326",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"
   },
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:25326"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

Backlog items from the status review, preparing for the v0.6.0 tag:

- **Release guard**: drop `workflow_dispatch` from release.yml — a manual run would publish a real release tagged `main` with 0.0.0-dev artifacts (`tagName: ${{ github.ref_name }}` + `releaseDraft: false`)
- **rpm checksums**: `bundle.targets: "all"` publishes an `.rpm` that the checksum job never downloaded
- **CSP** (was `null`): `script-src 'self'`, inline styles allowed for xterm.js, `data:`/`blob:` images, Tauri IPC + Vite dev websocket in `connect-src`
- **devUrl → 127.0.0.1**: matches vite.config.ts's documented Windows IPv6 workaround
- **Version sync to 0.6.0** across package.json / tauri.conf.json / Cargo.toml (+ both lockfiles refreshed; the regenerated package-lock drops the stale `@novnc/novnc` ghost entry)

Deliberately left out: the auto-updater config — wiring it end-to-end needs an update-signing keypair only the maintainer should custody (`npx tauri signer generate`, store as `TAURI_SIGNING_PRIVATE_KEY`, set `bundle.createUpdaterArtifacts`, add the `updater:default` capability, and a frontend `check()` call).

## Test plan
- `cargo metadata --locked` passes after the version bumps; `npm ci` clean on the regenerated lockfile; `tsc` clean; 27/27 tests
- CSP cannot be runtime-tested on this Linux box (no webview stack) — please smoke-test the app window when convenient; the policy is the standard Tauri shape and deliberately permissive on styles
- CI validates on all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)