### PR TITLE
docs: sync documentation with the actual codebase

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,10 +7,11 @@ Tauri 2.0 (Rust backend) + React + TypeScript (frontend).
 
 ## Project Context
 - **Framework**: Tauri 2.0, Tokio async runtime
-- **Protocols**: SSH/SFTP/SCP via `russh`, RDP via `IronRDP`, VNC via noVNC + 
-  Rust Websockify sidecar
+- **Protocols**: SSH via `russh`, RDP via `IronRDP`, VNC via `vnc-rs`
+  (native Rust RFB client; frames rendered to an HTML5 canvas)
 - **Frontend**: React + TypeScript + xterm.js for terminal panes
-- **Storage**: SQLite via `tauri-plugin-sql` for session management
+- **Storage**: JSON file (`%APPDATA%/RxTerm/sessions.json`) guarded by a
+  global async mutex — no database
 - **Target**: Windows (WebView2), offline-capable, minimal install (~10MB)
 
 ## Coding Standards

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-RxTerm is a lightweight desktop terminal and remote session management application targeting Windows. It supports SSH, VNC, and RDP connections from a single interface with session saving, split-screen layouts, and offline operation.
+RxTerm is a lightweight desktop terminal and remote session management application targeting Windows. It supports SSH, VNC, and RDP connections from a single interface with session saving, tabbed sessions, and offline operation.
 
 **Tech stack:** Tauri 2.0 (Rust backend) + React + TypeScript (frontend), licensed GPL-3.0.
 
@@ -29,12 +29,14 @@ cd src-tauri && cargo test             # run Rust unit tests
 cd src-tauri && cargo clippy           # lint (no config file — uses defaults)
 
 # Windows release script
-.\build-release.ps1 -Version 0.5.1
+.\build-release.ps1 -Version 0.6.0
 ```
 
 The Vite dev server is hardcoded to `127.0.0.1:25326` (IPv4) to avoid Windows IPv6 bind issues. Tauri expects this exact port via `tauri.conf.json`.
 
-There is no frontend test runner, no ESLint/Prettier config, and no Rust `rustfmt.toml`. The project relies on `tsc --strict` for frontend checks and `cargo clippy` for backend linting.
+There is no frontend test runner, no ESLint/Prettier config, and no Rust `rustfmt.toml`. The project relies on `tsc --strict` for frontend checks and `cargo clippy -- -D warnings` for backend linting (CI gates on both). Rust unit tests live in `#[cfg(test)]` modules (`session.rs`, `known_hosts.rs`, `vnc.rs` — the VNC tests drive the real session loop against an in-test RFB stub server using `tauri::test::mock_app()`).
+
+Note: `cargo test` on Windows requires the app manifest embedded into test executables — `build.rs` handles this (see the `windows-app-manifest.xml` comment); do not remove it or tests crash with `STATUS_ENTRYPOINT_NOT_FOUND`.
 
 ## Architecture
 
@@ -52,7 +54,7 @@ When adding a new command:
 
 Each protocol has a dedicated manager registered as Tauri managed state (`tauri::manage()`):
 - **`SshConnectionManager`** (`ssh.rs`) — russh sessions, PTY channels, and reader tasks
-- **`VncConnectionManager`** (`vnc.rs`) — localhost WebSocket-to-TCP proxy per connection; frontend noVNC connects to the proxy
+- **`VncConnectionManager`** (`vnc.rs`) — native `vnc-rs` RFB client per connection; runs the protocol in a tokio task, maintains a local framebuffer, sends incremental refresh requests on a ticker, and emits tiled (256×256) base64-RGBA `vnc-frame` events rendered by the canvas-based `VncPane`
 - **`RdpConnectionManager`** (`rdp.rs`) — IronRDP sessions, emits `rdp-frame` events with RGBA pixel data
 
 All managers use `Arc<Mutex<HashMap<String, ...>>>` for thread-safe connection tracking keyed by UUID connection IDs.
@@ -62,6 +64,7 @@ All managers use `Arc<Mutex<HashMap<String, ...>>>` for thread-safe connection t
 Tauri events for real-time data:
 - `ssh-output-{connection_id}` / `ssh-closed-{connection_id}` — terminal data and disconnection
 - `rdp-frame` / `rdp-disconnected` — RDP frame updates (dirty rectangles) and session end
+- `vnc-frame` / `vnc-disconnected` / `vnc-clipboard` — tiled VNC frame updates, session end (with reason), and server clipboard text
 
 ### Frontend State
 
@@ -99,11 +102,13 @@ The version string lives in three files that must stay in sync:
 - `src-tauri/tauri.conf.json` → `version`
 - `src-tauri/Cargo.toml` → `version`
 
-The CI release workflow and `build-release.ps1` handle this automatically from a git tag. For local dev, keep them consistent manually.
+The CI release workflow patches all three automatically from the git tag at build time (`build-release.ps1` patches only `package.json` and `tauri.conf.json` — bump `Cargo.toml` yourself when using it). For local dev, keep them consistent manually.
 
 ## CI/CD
 
-The release workflow (`.github/workflows/release.yml`) triggers on `v*` tags and builds for Windows, macOS (universal binary), and Linux using `tauri-apps/tauri-action`. It also produces a Windows portable zip and SHA-256 checksums. Code signing is scaffolded but currently disabled.
+Every pull request and push to main runs `.github/workflows/ci.yml`: frontend `tsc && vite build`, plus `cargo clippy --all-targets --locked -- -D warnings` and `cargo test --locked` on ubuntu, windows, and macos.
+
+The release workflow (`.github/workflows/release.yml`) triggers on `v*` tags only and builds for Windows, macOS (universal binary), and Linux using `tauri-apps/tauri-action`. It also produces a Windows portable zip and SHA-256 checksums. Code signing is scaffolded but currently disabled, and the auto-updater config in `tauri.conf.json` is inert until an update-signing keypair is provisioned.
 
 ## Things to Avoid
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ The CI release workflow patches all three automatically from the git tag at buil
 
 ## CI/CD
 
-Every pull request and push to main runs `.github/workflows/ci.yml`: frontend `tsc && vite build`, plus `cargo clippy --all-targets --locked -- -D warnings` and `cargo test --locked` on ubuntu, windows, and macos.
+Every pull request and push to main runs `.github/workflows/ci.yml`: frontend `tsc && vite build`, plus `cargo test --locked` on ubuntu, windows, and macos, with `cargo clippy --all-targets --locked -- -D warnings` gating on ubuntu (the codebase has no cfg-gated platform code, so lints are identical everywhere).
 
 The release workflow (`.github/workflows/release.yml`) triggers on `v*` tags only and builds for Windows, macOS (universal binary), and Linux using `tauri-apps/tauri-action`. It also produces a Windows portable zip and SHA-256 checksums. Code signing is scaffolded but currently disabled, and the auto-updater config in `tauri.conf.json` is inert until an update-signing keypair is provisioned.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RxTerm
 
-A lightweight, modern terminal and remote session management program built for daily use on Windows. RxTerm aims to provide a streamlined, minimal-setup experience for managing SSH, VNC, and RDP connections — with first-class support for split-screen layouts, tunneling, file transfers, and offline operation.
+A lightweight, modern terminal and remote session management program built for daily use on Windows. RxTerm provides a streamlined, minimal-setup experience for managing SSH, RDP, and VNC connections from a single tabbed interface, fully offline-capable.
 
 Licensed under the [GNU General Public License v3.0](LICENSE).
 
@@ -8,64 +8,71 @@ Licensed under the [GNU General Public License v3.0](LICENSE).
 
 ## Features
 
-### Remote Session Management
-- **SSH, VNC, and RDP** — Connect to remote machines using all three major protocols from a single interface.
-- **Session Saving & Export** — Save session configurations (host, port, credentials, protocol) and export/import them for backup or sharing.
-- **SSH Key Management** — Generate SSH key pairs and send public keys to remote hosts directly from the application.
+### Remote Sessions
+- **SSH terminal** — full xterm.js terminal over `russh`, with password and key-file authentication, host-key verification (distinct warning when a stored key changes), and PTY resize.
+- **RDP remote desktop** — native IronRDP client rendering to an HTML5 canvas with keyboard and mouse input.
+- **VNC remote desktop** — native Rust RFB client (`vnc-rs`) with canvas rendering, keyboard/mouse input, and bidirectional clipboard.
 
-### Terminal & Layout
-- **Split-Screen Support** — Divide the terminal view into multiple panes to work with several sessions side-by-side.
-- **tmux Detection** — Automatically check for tmux support on connected hosts and detect/attach to existing tmux sessions.
-
-### Tunneling & Port Forwarding
-- **Local & Remote Tunneling** — Set up SSH tunnels and port forwarding rules with a simple configuration interface.
-
-### File Transfer
-- **SFTP, SCP, and FTP** — Transfer files to and from remote hosts using the most common protocols, integrated into the session workflow.
-
-### Server Monitoring
-- **Resource Dashboard** — Monitor real-time memory and CPU usage on connected servers at a glance.
+### Session Management
+- **Save, edit, and organize** sessions (host, port, protocol — passwords are never persisted to disk).
+- **Export / import** session lists as JSON for backup or sharing.
+- **Tabbed layout** — run multiple sessions side by side in tabs, Windows Terminal-style.
 
 ### Design Goals
-- **Windows-First** — Built to run natively on Windows with no heavy dependencies.
-- **Minimal Setup** — Get up and running quickly — no complex installation or configuration required.
-- **Lightweight & Offline-Capable** — Small footprint with full functionality available without an internet connection.
+- **Windows-first** — native WebView2, no Electron, small footprint.
+- **Minimal setup** — portable zip needs no installation at all.
+- **Offline-capable** — full functionality without an internet connection.
 
 ---
 
-## Getting Started
+## Installation
 
-> **Note:** RxTerm is in early development. Setup instructions and release binaries will be provided as the project matures.
+Download from the [latest release](https://github.com/rexc-lab/RxTerm/releases/latest):
 
-### Prerequisites
-- Windows 10 or later
+- **Windows installer** — `RxTerm_<version>_x64_en-US.msi` or the `.exe` (NSIS) installer
+- **Windows portable** — `RxTerm_<version>_windows_portable.zip`: unzip and run `rxterm.exe`, no installation required (settings live in `%APPDATA%\RxTerm\`)
+- macOS (`.dmg`, universal) and Linux (`.deb` / `.rpm` / `.AppImage`) builds are published too, though Windows is the primary target
 
-### Installation
-_Coming soon._
+SHA-256 checksums (`checksums-sha256.txt`) accompany every release. Binaries are not yet code-signed, so Windows SmartScreen may prompt on first run.
 
-### Usage
-_Coming soon._
+### Building from source
+
+```bash
+npm ci
+npx tauri dev     # development window with hot reload
+npx tauri build   # release bundle
+```
+
+Requires Node 22+, Rust stable, and on Linux the WebKitGTK dev stack (see `.github/workflows/ci.yml`).
 
 ---
 
 ## Roadmap
 
-- [ ] Core terminal emulator with split-screen panes
-- [ ] SSH session management and connection handling
-- [ ] VNC and RDP session integration
-- [ ] Session save/load/export functionality
+Shipped:
+
+- [x] SSH session management and connection handling
+- [x] RDP and VNC session integration
+- [x] Session save/load/export functionality
+- [x] Tabbed session layout
+- [x] Offline-capable packaging (portable zip)
+
+Planned (not yet implemented):
+
+- [ ] Split-screen panes
 - [ ] SSH key generation and deployment
 - [ ] SSH tunneling and port forwarding
-- [ ] SFTP / SCP / FTP file transfer
+- [ ] SFTP / SCP file transfer
 - [ ] tmux detection and session attachment
 - [ ] Server resource monitoring (CPU & memory)
-- [ ] Offline-capable packaging
+- [ ] Auto-update
+- [ ] Code-signed binaries
 
 ---
 
 ## Contributing
 
-Contributions are welcome. Please open an issue to discuss proposed changes before submitting a pull request.
+Contributions are welcome. Please open an issue to discuss proposed changes before submitting a pull request. Every PR is validated by CI (`tsc`, `cargo clippy -D warnings`, and the test suite on Windows, Linux, and macOS).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Planned (not yet implemented):
 
 ## Contributing
 
-Contributions are welcome. Please open an issue to discuss proposed changes before submitting a pull request. Every PR is validated by CI (`tsc`, `cargo clippy -D warnings`, and the test suite on Windows, Linux, and macOS).
+Contributions are welcome. Please open an issue to discuss proposed changes before submitting a pull request. Every PR is validated by CI: `tsc`, the Rust test suite on Windows, Linux, and macOS, and `cargo clippy -D warnings` on Linux.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-13-vnc-host-support.md
+++ b/docs/superpowers/plans/2026-04-13-vnc-host-support.md
@@ -35,7 +35,7 @@
 - Modify: `src-tauri/Cargo.toml`
 - Modify: `src-tauri/src/session.rs`
 
-- [ ] **Step 1: Add vnc-rs to Cargo.toml**
+- [x] **Step 1: Add vnc-rs to Cargo.toml**
 
 In `src-tauri/Cargo.toml`, add to the `[dependencies]` section after the `tokio-native-tls` line:
 
@@ -44,7 +44,7 @@ In `src-tauri/Cargo.toml`, add to the `[dependencies]` section after the `tokio-
 vnc-rs = "0.5"
 ```
 
-- [ ] **Step 2: Add Vnc variant to Protocol enum in session.rs**
+- [x] **Step 2: Add Vnc variant to Protocol enum in session.rs**
 
 In `src-tauri/src/session.rs`, change the `Protocol` enum from:
 
@@ -70,12 +70,12 @@ pub enum Protocol {
 }
 ```
 
-- [ ] **Step 3: Verify it compiles**
+- [x] **Step 3: Verify it compiles**
 
 Run: `cd src-tauri && cargo check`
 Expected: Compiles successfully (may have warnings about unused `Vnc` variant — that's fine at this stage).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/src/session.rs
@@ -90,7 +90,7 @@ git commit -m "feat: add vnc-rs dependency and Protocol::Vnc variant"
 - Create: `src-tauri/src/vnc.rs`
 - Modify: `src-tauri/src/lib.rs`
 
-- [ ] **Step 1: Create vnc.rs with types, error, and manager skeleton**
+- [x] **Step 1: Create vnc.rs with types, error, and manager skeleton**
 
 Create `src-tauri/src/vnc.rs`:
 
@@ -743,7 +743,7 @@ impl serde::Serialize for VncError {
 }
 ```
 
-- [ ] **Step 2: Register the vnc module in lib.rs**
+- [x] **Step 2: Register the vnc module in lib.rs**
 
 In `src-tauri/src/lib.rs`, add `pub mod vnc;` after the existing module declarations:
 
@@ -766,12 +766,12 @@ pub mod ssh;
 pub mod vnc;
 ```
 
-- [ ] **Step 3: Verify it compiles**
+- [x] **Step 3: Verify it compiles**
 
 Run: `cd src-tauri && cargo check`
 Expected: Compiles successfully. The `vnc` module is registered but its manager is not yet wired into commands.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src-tauri/src/vnc.rs src-tauri/src/lib.rs
@@ -786,7 +786,7 @@ git commit -m "feat: add VncConnectionManager with session runner and framebuffe
 - Modify: `src-tauri/src/commands.rs`
 - Modify: `src-tauri/src/lib.rs`
 
-- [ ] **Step 1: Add VNC imports and AppError::Vnc to commands.rs**
+- [x] **Step 1: Add VNC imports and AppError::Vnc to commands.rs**
 
 In `src-tauri/src/commands.rs`, add the VNC import to the existing use block. Change:
 
@@ -841,7 +841,7 @@ pub enum AppError {
 }
 ```
 
-- [ ] **Step 2: Add VNC command functions to commands.rs**
+- [x] **Step 2: Add VNC command functions to commands.rs**
 
 Append the following after the RDP commands section at the end of `commands.rs`:
 
@@ -953,7 +953,7 @@ pub async fn vnc_send_clipboard(
 }
 ```
 
-- [ ] **Step 3: Register VNC manager and commands in lib.rs**
+- [x] **Step 3: Register VNC manager and commands in lib.rs**
 
 In `src-tauri/src/lib.rs`, update the imports. Change:
 
@@ -1043,12 +1043,12 @@ To:
         ])
 ```
 
-- [ ] **Step 4: Verify it compiles**
+- [x] **Step 4: Verify it compiles**
 
 Run: `cd src-tauri && cargo check`
 Expected: Compiles successfully. All VNC commands are registered and wired up.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src-tauri/src/commands.rs src-tauri/src/lib.rs
@@ -1063,7 +1063,7 @@ git commit -m "feat: add VNC Tauri commands and register manager"
 - Modify: `src/types.ts`
 - Modify: `src/api.ts`
 
-- [ ] **Step 1: Update Protocol type and add VNC types in types.ts**
+- [x] **Step 1: Update Protocol type and add VNC types in types.ts**
 
 In `src/types.ts`, change the Protocol type:
 
@@ -1124,7 +1124,7 @@ export function emptyVncDraft(): SshSessionDraft {
 }
 ```
 
-- [ ] **Step 2: Add VNC API wrappers in api.ts**
+- [x] **Step 2: Add VNC API wrappers in api.ts**
 
 In `src/api.ts`, add the VNC section after the RDP commands. Also add `emptyVncDraft` to any needed imports if the file imports from types (it currently doesn't import draft helpers, so no import change needed).
 
@@ -1185,12 +1185,12 @@ export async function vncSendClipboard(
 }
 ```
 
-- [ ] **Step 3: Verify frontend compiles**
+- [x] **Step 3: Verify frontend compiles**
 
 Run: `npm run build`
 Expected: TypeScript compilation succeeds (the new types and functions are exported but not yet consumed by components).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/types.ts src/api.ts
@@ -1204,7 +1204,7 @@ git commit -m "feat: add VNC types and API wrappers to frontend"
 **Files:**
 - Create: `src/components/VncPane.tsx`
 
-- [ ] **Step 1: Create VncPane.tsx**
+- [x] **Step 1: Create VncPane.tsx**
 
 Create `src/components/VncPane.tsx`:
 
@@ -1495,12 +1495,12 @@ export default function VncPane({ connectionId, onDisconnected, onReconnect }: V
 }
 ```
 
-- [ ] **Step 2: Verify frontend compiles**
+- [x] **Step 2: Verify frontend compiles**
 
 Run: `npm run build`
 Expected: TypeScript compilation succeeds.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add src/components/VncPane.tsx
@@ -1514,7 +1514,7 @@ git commit -m "feat: add VncPane canvas-based VNC viewer component"
 **Files:**
 - Modify: `src/components/SshSessionForm.tsx`
 
-- [ ] **Step 1: Add VNC import and protocol option**
+- [x] **Step 1: Add VNC import and protocol option**
 
 In `src/components/SshSessionForm.tsx`, update the import to include `emptyVncDraft`:
 
@@ -1522,7 +1522,7 @@ In `src/components/SshSessionForm.tsx`, update the import to include `emptyVncDr
 import { emptySshDraft, emptyRdpDraft, emptyVncDraft } from "../types";
 ```
 
-- [ ] **Step 2: Add VNC to handleProtocolChange**
+- [x] **Step 2: Add VNC to handleProtocolChange**
 
 Change the `handleProtocolChange` function from:
 
@@ -1566,7 +1566,7 @@ To:
   };
 ```
 
-- [ ] **Step 3: Add VNC option to protocol dropdown**
+- [x] **Step 3: Add VNC option to protocol dropdown**
 
 Change the protocol select from:
 
@@ -1595,7 +1595,7 @@ To:
         </select>
 ```
 
-- [ ] **Step 4: Add isVnc variable and VNC-specific form fields**
+- [x] **Step 4: Add isVnc variable and VNC-specific form fields**
 
 After the existing `isRdp` variable:
 
@@ -1645,12 +1645,12 @@ Add a VNC fields block after the RDP fields block (after the closing `</>` of `{
       )}
 ```
 
-- [ ] **Step 5: Verify frontend compiles**
+- [x] **Step 5: Verify frontend compiles**
 
 Run: `npm run build`
 Expected: TypeScript compilation succeeds.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/components/SshSessionForm.tsx
@@ -1664,7 +1664,7 @@ git commit -m "feat: add VNC protocol option to session form"
 **Files:**
 - Modify: `src/components/SessionList.tsx`
 
-- [ ] **Step 1: Update protocol badge logic**
+- [x] **Step 1: Update protocol badge logic**
 
 In `src/components/SessionList.tsx`, change the `protoBadge` assignment from:
 
@@ -1678,7 +1678,7 @@ To:
         const protoBadge = proto === "rdp" ? "RDP" : proto === "vnc" ? "VNC" : "SSH";
 ```
 
-- [ ] **Step 2: Update tooltip**
+- [x] **Step 2: Update tooltip**
 
 Change the tooltip from:
 
@@ -1700,7 +1700,7 @@ To:
               : `${s.username}@${s.host}:${s.port} — Double-click to connect`;
 ```
 
-- [ ] **Step 3: Update detail display for VNC (no username required)**
+- [x] **Step 3: Update detail display for VNC (no username required)**
 
 Change the detail from:
 
@@ -1720,12 +1720,12 @@ To:
             : `${s.username}@${s.host}:${s.port}`;
 ```
 
-- [ ] **Step 4: Verify frontend compiles**
+- [x] **Step 4: Verify frontend compiles**
 
 Run: `npm run build`
 Expected: TypeScript compilation succeeds.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/components/SessionList.tsx
@@ -1739,7 +1739,7 @@ git commit -m "feat: add VNC protocol badge to session list"
 **Files:**
 - Modify: `src/App.tsx`
 
-- [ ] **Step 1: Add VNC imports**
+- [x] **Step 1: Add VNC imports**
 
 Update the component import at the top of `App.tsx`. Change:
 
@@ -1790,7 +1790,7 @@ import {
 } from "./api";
 ```
 
-- [ ] **Step 2: Add VNC connection flow to handleConnect**
+- [x] **Step 2: Add VNC connection flow to handleConnect**
 
 In the `handleConnect` function, add a VNC branch before the SSH flow. Change:
 
@@ -1863,7 +1863,7 @@ To:
       }
 ```
 
-- [ ] **Step 3: Add VNC disconnect to handleDisconnect**
+- [x] **Step 3: Add VNC disconnect to handleDisconnect**
 
 Update the `handleDisconnect` function. Change:
 
@@ -1887,7 +1887,7 @@ To:
       }
 ```
 
-- [ ] **Step 4: Add VncPane to tab content rendering**
+- [x] **Step 4: Add VncPane to tab content rendering**
 
 Update the tab content area where panes are rendered. Change:
 
@@ -1941,12 +1941,12 @@ To:
                   )}
 ```
 
-- [ ] **Step 5: Verify frontend compiles**
+- [x] **Step 5: Verify frontend compiles**
 
 Run: `npm run build`
 Expected: TypeScript compilation succeeds with no errors.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/App.tsx
@@ -1959,22 +1959,22 @@ git commit -m "feat: wire VNC connection flow and VncPane into App"
 
 **Files:** None (verification only)
 
-- [ ] **Step 1: Run Rust checks**
+- [x] **Step 1: Run Rust checks**
 
 Run: `cd src-tauri && cargo clippy`
 Expected: No errors. Fix any clippy warnings.
 
-- [ ] **Step 2: Run TypeScript checks**
+- [x] **Step 2: Run TypeScript checks**
 
 Run: `npm run build`
 Expected: Clean build with no errors.
 
-- [ ] **Step 3: Run Rust tests**
+- [x] **Step 3: Run Rust tests**
 
 Run: `cd src-tauri && cargo test`
 Expected: All existing tests pass (session validation, host validation, password serialization).
 
-- [ ] **Step 4: Start dev server and verify UI**
+- [x] **Step 4: Start dev server and verify UI**
 
 Run: `npx tauri dev`
 Expected:
@@ -1984,7 +1984,7 @@ Expected:
 - VNC session can be saved and appears in the session list with "VNC" badge
 - Session list shows `host:port` format for VNC (no username prefix)
 
-- [ ] **Step 5: Final commit if any fixes were needed**
+- [x] **Step 5: Final commit if any fixes were needed**
 
 ```bash
 git add -A

--- a/docs/superpowers/specs/2026-04-13-vnc-host-support-design.md
+++ b/docs/superpowers/specs/2026-04-13-vnc-host-support-design.md
@@ -1,7 +1,7 @@
 # VNC Host Support — Design Spec
 
 **Date:** 2026-04-13
-**Status:** Approved
+**Status:** Implemented (merged via PR #11, 2026-04-14)
 **Approach:** Pure Rust VNC client using `vnc-rs` crate (Approach A)
 
 ## Summary


### PR DESCRIPTION
## Summary

Docs-drift items from the status review. CLAUDE.md now describes the real vnc-rs architecture (events, tabbed layout, CI gates, the Windows test-manifest gotcha); copilot-instructions.md drops the fictional noVNC/Websockify/SQLite stack; README features are honest (shipped vs planned separated, real installation instructions pointing at release assets); the VNC design spec is marked Implemented with all plan checkboxes checked.

Note: a couple of lines reference the changed-host-key warning (#14) and v0.6.0 versions (#15) — intended merge order is #14 → #15 → this.

## Test plan
- Docs-only; CI still runs the full suite
- Every factual claim verified against the current code during the session's adversarial review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)