### PR TITLE
ci: add SignPath Windows code signing to the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,9 +212,81 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber
 
+  # ── Windows code signing (SignPath) ─────────────────────────────────
+  #
+  # Signs the NSIS (.exe) and MSI installers via SignPath's remote signing
+  # service and re-uploads the signed versions to the release. INERT until
+  # SignPath is fully set up: it only runs when the repository variable
+  # SIGNING_ENABLED is 'true'. Until then, releases ship unsigned and this
+  # job is skipped — see docs/SIGNING.md for the one-time setup.
+  #
+  # NOTE: this signs the installers, not the bare rxterm.exe inside the
+  # portable zip (that needs signing before zipping — a follow-up).
+  sign-windows:
+    name: Sign Windows installers (SignPath)
+    needs: build
+    if: vars.SIGNING_ENABLED == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download unsigned Windows installers from the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          mkdir -p unsigned
+          # Wait briefly for the release to be fully published by the build job.
+          sleep 10
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --dir unsigned \
+            --pattern "*.exe" \
+            --pattern "*.msi" \
+            --clobber
+
+      - name: Upload unsigned installers as a workflow artifact
+        id: upload-unsigned
+        uses: actions/upload-artifact@v4
+        with:
+          name: rxterm-windows-unsigned
+          path: unsigned/
+          if-no-files-found: error
+
+      - name: Submit signing request to SignPath
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          connector-url: ${{ vars.SIGNPATH_CONNECTOR_URL }}
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed
+
+      - name: Re-upload signed installers to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          # The signed artifact preserves the uploaded directory layout.
+          gh release upload "$TAG" signed/*.exe signed/*.msi \
+            --repo "${{ github.repository }}" \
+            --clobber
+
   # ── Checksums ───────────────────────────────────────────────────────
   checksums:
-    needs: build
+    # Runs after signing when it is enabled (so checksums cover the signed
+    # binaries), or directly after build when signing is skipped. A FAILED
+    # signing job blocks checksums so a half-signed release is never hashed.
+    needs: [build, sign-windows]
+    if: >-
+      ${{ always()
+      && needs.build.result == 'success'
+      && (needs.sign-windows.result == 'success' || needs.sign-windows.result == 'skipped') }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -33,7 +33,16 @@ Download from the [latest release](https://github.com/rexc-lab/RxTerm/releases/l
 - **Windows portable** — `RxTerm_<version>_windows_portable.zip`: unzip and run `rxterm.exe`, no installation required (settings live in `%APPDATA%\RxTerm\`)
 - macOS (`.dmg`, universal) and Linux (`.deb` / `.rpm` / `.AppImage`) builds are published too, though Windows is the primary target
 
-SHA-256 checksums (`checksums-sha256.txt`) accompany every release. Binaries are not yet code-signed, so Windows SmartScreen may prompt on first run.
+SHA-256 checksums (`checksums-sha256.txt`) accompany every release.
+
+**Windows SmartScreen note:** on first run Windows may show "Windows
+protected your PC." This is expected for a newer app that hasn't yet built
+download reputation — click **More info → Run anyway** after confirming the
+publisher. (You can also right-click the download → Properties → **Unblock**
+before running.) Installers are being code-signed via SignPath; the
+"Unknown Publisher" label clears with signing, while the SmartScreen
+reputation prompt fades as more people install over time. See
+[docs/SIGNING.md](docs/SIGNING.md) for details.
 
 ### Building from source
 

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -1,0 +1,82 @@
+# Windows code signing (SignPath)
+
+RxTerm's Windows installers are signed via [SignPath Foundation](https://signpath.org/),
+which provides free code signing for open-source projects. The release
+workflow (`.github/workflows/release.yml`) has a `sign-windows` job that is
+**inert until you complete the one-time setup below** and set the
+`SIGNING_ENABLED` repository variable to `true`. Until then, releases ship
+unsigned and the job is skipped.
+
+## What signing does (and does not) fix
+
+Two separate Windows warnings, per
+[Microsoft's current docs](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation):
+
+- **UAC "Unknown Publisher"** — fixed **immediately** by the first signed
+  release. The elevation prompt then shows "SignPath Foundation" as the
+  verified publisher.
+- **SmartScreen "Windows protected your PC / unrecognized app"** — **not**
+  fixed immediately. It is reputation-based and clears only as the signed
+  binaries accumulate clean downloads (Microsoft's estimate: "several weeks
+  and hundreds of clean installs," with no guaranteed date and no expedite
+  path short of the Microsoft Store). Paying for an EV certificate would
+  **not** change this — Microsoft removed EV's instant-reputation privilege
+  in 2024.
+
+Reputation accrues to the signing **certificate identity** as well as each
+file hash, so signing every release with the same SignPath identity from the
+first signed build onward is what makes the warning fade fastest.
+
+## One-time setup
+
+### 1. Apply to SignPath Foundation
+Apply at <https://signpath.org/> with the RxTerm repo. The project qualifies
+(GPL-3.0 is an OSI-approved license). Approval is manual and can take a few
+days. You'll be given a SignPath **organization**.
+
+### 2. Configure the SignPath organization (SignPath web UI)
+- Add the predefined **GitHub.com** trusted build system to the organization.
+- Create a **project** (note its *project slug*, e.g. `rxterm`) and link the
+  GitHub trusted build system to it, pointing at this repository.
+- Create an **artifact configuration** describing the files to sign — a
+  directory (the uploaded `unsigned/` artifact) containing the NSIS `.exe`
+  and the `.msi`, each Authenticode-signed. Note its *artifact configuration
+  slug*.
+- Create a **signing policy** (e.g. `release-signing`) tied to that artifact
+  configuration. Note its *signing policy slug*.
+- Enable **origin verification** (required for the free Foundation program).
+
+### 3. Add the policy file to this repo
+SignPath's Foundation onboarding gives you the exact contents for
+`.signpath/policies/<project-slug>/<signing-policy-slug>.yml`. Commit that
+file to the default branch (it enforces constraints like branch protection
+and no build reruns). Use the content SignPath provides verbatim — do not
+hand-write it.
+
+### 4. Add repository secrets and variables
+In **Settings → Secrets and variables → Actions**:
+
+Secret:
+- `SIGNPATH_API_TOKEN` — a SignPath REST API token
+
+Variables:
+- `SIGNPATH_CONNECTOR_URL` — the connector URL shown in your SignPath UI
+- `SIGNPATH_ORGANIZATION_ID` — your SignPath organization ID
+- `SIGNPATH_PROJECT_SLUG` — e.g. `rxterm`
+- `SIGNPATH_SIGNING_POLICY_SLUG` — e.g. `release-signing`
+- `SIGNPATH_ARTIFACT_CONFIGURATION_SLUG` — from step 2
+- `SIGNING_ENABLED` — set to `true` to turn the `sign-windows` job on
+
+### 5. Test before a real release
+Push a throwaway pre-release tag (e.g. `v0.6.1-rc1`) and confirm the
+`sign-windows` job succeeds and the release's `.exe`/`.msi` verify as signed
+(`signtool verify /pa /v file` on Windows, or check the file's Digital
+Signatures tab). Only then tag a real release. If anything is misconfigured,
+unset `SIGNING_ENABLED` to fall back to unsigned releases.
+
+## Known follow-ups
+- The bare `rxterm.exe` inside the portable zip is **not** signed by this job
+  (it is zipped during the build, before signing). Signing it requires
+  signing the binary before the portable zip is created.
+- Code signing is unrelated to the Tauri **updater** signing key
+  (`TAURI_SIGNING_PRIVATE_KEY`), which signs update manifests, not binaries.


### PR DESCRIPTION
## Summary

Wires SignPath remote code signing into `release.yml` so Windows installers get an Authenticode signature. Implemented as a **gated, inert-until-configured** addition so it can't break the working release pipeline:

- New `sign-windows` job signs the NSIS `.exe` + `.msi` (via `signpath/github-action-submit-signing-request@v2`) and re-uploads the signed versions to the release.
- Runs **only** when the repo variable `SIGNING_ENABLED == 'true'`; otherwise skipped and releases ship unsigned as today.
- `checksums` now `needs: [build, sign-windows]` and runs after signing (so hashes cover signed binaries) or directly after build when signing is skipped — and is **blocked if signing fails**, so a half-signed release is never hashed.
- `docs/SIGNING.md`: the one-time SignPath Foundation setup runbook (the parts only you can do — application, org/project/artifact-config/policy, the `.signpath` policy file, secrets/vars, and a pre-release test).
- README: honest SmartScreen expectations for users.

## What still needs you (can't be automated)

SignPath Foundation requires manual OSS-program approval and an artifact configuration created in their web UI. The workflow references `SIGNPATH_*` secrets/variables you add once approved. **Test on a throwaway pre-release tag** (e.g. `v0.6.1-rc1`) before flipping `SIGNING_ENABLED` on a real release — I can't exercise the signing path from here.

## Test plan
- `release.yml` YAML validated; gating verified (`sign-windows` skips when `SIGNING_ENABLED` unset; `checksums` waits for success-or-skipped, blocks on failure)
- PR CI (frontend + Rust) is unaffected by these workflow/docs changes
- The release workflow itself only runs on `v*` tags, so end-to-end signing is validated by your pre-release test, not PR CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)